### PR TITLE
🩹 fix: user테이블 nickname unique-false로 변경

### DIFF
--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -30,7 +30,7 @@ export class User {
   @Column({ type: 'varchar', select: false, nullable: false })
   password: string;
 
-  @Column({ type: 'varchar', unique: true, nullable: false })
+  @Column({ type: 'varchar', unique: false, nullable: false })
   nickname: string;
 
   @Column({ type: 'int', default: UserRole.USER })


### PR DESCRIPTION
- 여러 SNS로 가입할 때 닉네임이 중복불가한 상황이 나와서 엔티티상 유니크 허용합니다.
- 아이디별 정보가 다른건 유저의 몫으로 결정